### PR TITLE
Added azuread provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ module "azure-key-vault-tfvars" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.9 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.3.6 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.41.0 |
 
 ## Providers

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,15 @@
 terraform {
   required_version = ">= 1.3.9"
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 3.41.0"
+    }
+
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.3.6"
     }
   }
 }


### PR DESCRIPTION
`tflint` expects the `azuread` provider to be added because it's in use as a data source