### PR TITLE
Tighten ACLs for Key Vault network rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ module "azure_key_vault_tfvars" {
     "my_email.address.suffix#EXT#@platformidentity.onmicrosoft.com",
   ]
 
+  # List of IPV4 Addresses that are permitted to access the Key Vault
+  key_vault_access_ipv4 = [
+    "8.8.8.8"
+  ]
+
+  ## Specify a list of Azure Subnet Resource IDs that can access this Key Vault
+  # key_vault_access_subnet_ids = [
+  #   "/my/azure/subnet/id"
+  # ]
+
   tfvars_filename = "dev.tfvars"
 
   tags = {
@@ -74,7 +84,9 @@ module "azure_key_vault_tfvars" {
 | <a name="input_enable_resource_group_lock"></a> [enable\_resource\_group\_lock](#input\_enable\_resource\_group\_lock) | Enabling this will add a Resource Lock to the Resource Group preventing any resources from being deleted. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Name of an existing Resource Group to create the Key Vault within | `string` | n/a | yes |
-| <a name="input_key_vault_access_users"></a> [key\_vault\_access\_users](#input\_key\_vault\_access\_users) | List of users that require access to the Key Vault where tfvars are stored. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | n/a | yes |
+| <a name="input_key_vault_access_ipv4"></a> [key\_vault\_access\_ipv4](#input\_key\_vault\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the Key Vault | `list(string)` | n/a | yes |
+| <a name="input_key_vault_access_subnet_ids"></a> [key\_vault\_access\_subnet\_ids](#input\_key\_vault\_access\_subnet\_ids) | List of Azure Subnet IDs that are permitted to access the Key Vault | `list(string)` | `[]` | no |
+| <a name="input_key_vault_access_users"></a> [key\_vault\_access\_users](#input\_key\_vault\_access\_users) | List of users that require access to the Key Vault. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to be applied to all resources | `map(string)` | `{}` | no |
 | <a name="input_tfvars_filename"></a> [tfvars\_filename](#input\_tfvars\_filename) | tfvars filename. This file is uploaded and stored encrupted within Key Vault, to ensure that the latest tfvars are stored in a shared place. | `string` | n/a | yes |

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,8 @@ locals {
   resource_group                        = local.existing_resource_group == "" ? azurerm_resource_group.default[0] : data.azurerm_resource_group.existing_resource_group[0]
   enable_resource_group_lock            = var.enable_resource_group_lock
   key_vault_access_users                = toset(var.key_vault_access_users)
+  key_vault_access_ipv4                 = var.key_vault_access_ipv4
+  key_vault_access_subnet_ids           = var.key_vault_access_subnet_ids
   tfvars_filename                       = var.tfvars_filename
   enable_diagnostic_setting             = var.enable_diagnostic_setting
   enable_diagnostic_retention_policy    = var.enable_diagnostic_retention_policy

--- a/variables.tf
+++ b/variables.tf
@@ -25,8 +25,19 @@ variable "azure_location" {
 }
 
 variable "key_vault_access_users" {
-  description = "List of users that require access to the Key Vault where tfvars are stored. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform"
+  description = "List of users that require access to the Key Vault. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform"
   type        = list(string)
+}
+
+variable "key_vault_access_ipv4" {
+  description = "List of IPv4 Addresses that are permitted to access the Key Vault"
+  type        = list(string)
+}
+
+variable "key_vault_access_subnet_ids" {
+  description = "List of Azure Subnet IDs that are permitted to access the Key Vault"
+  type        = list(string)
+  default     = []
 }
 
 variable "tfvars_filename" {


### PR DESCRIPTION
This PR tightens up the security of the TF Vars Key Vault by requiring a list of trusted IPv4 addresses

```hcl
# List of IPV4 Addresses that are permitted to access the Key Vault
key_vault_access_ipv4 = [
  "x.x.x.x"
]
```

Additionally, it will now also support including a list of authorised Subnet IDs where resources may need to connect to Key Vault