### PR TITLE
Do not allow older tfvars file to be uploaded to Key Vault

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -16,6 +16,18 @@ provider "registry.terraform.io/hashicorp/azuread" {
     "h1:jmvCGhwc+jUip0Hy4PI1ZiO/11vdQ3TTp3YaBTKFGiQ=",
     "h1:tB16uWp5AfxDeFJQQfIGMvLjpqAprDT0tvLX0VyS51M=",
     "h1:tU/kGFohqNia+uVFT1ujYKZRH2lvEP73LUhQDJtO1w4=",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:2225e2e97ccba4ed1d84f1d430f1ebd837943fe187e57f24f1763172dda61556",
+    "zh:24708cb09411a766ff397e05cae49058ca38edc718db303a7faef9823402737d",
+    "zh:3a61167ff58d585abd56233731a8fd649c7c04272bd5b878f963883496e19192",
+    "zh:433f557634b5e663caaeb68c504c7771c186eba7ecf5d4030437956bc6599ecb",
+    "zh:5e8cc3b3bcc22d217cf588c821ce091c7d40f0815aecc1addde5355c17cb381d",
+    "zh:7b008c376097cd60259d43f58fcb33fee56fe9aebb4a94ed7958868ee501d7d0",
+    "zh:908907fd38537583ea60dccbf73055ae1a2963acc399be4f8e9a6616a9a537db",
+    "zh:966586cfd850606bab7dd2242c5b9e35d3a7178f64eaac0b44dea54c104c8169",
+    "zh:a624286401913d3ec44b4825e2c5ae38ac94fb4950aeed8f4b91d09c898f8cce",
+    "zh:b5171a4463fd0d9b0ce2a08605499b6d99fe93d6fc3f4143e9a26201065cc90a",
+    "zh:cdcfeeb9db4dbdc6f1fb5644453b37dbd0025b4f3127e9ff348f1e62d66b493e",
   ]
 }
 
@@ -34,5 +46,36 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "h1:jdCddD1ADiQQB/rjC2aB7fFzOMZswHRPcVVC6YmL5K0=",
     "h1:kYGXRzbJpeHh95Dm7OQaqUnG/wy/GRlaZ3EzMJnUI/4=",
     "h1:p1Gx4LldGfKHDKHwZU71wS2tglVIyE0d0rxkXrkG0HA=",
+    "zh:0d881d7b499367400ced6e315e32a1948d823309c5677a16056367001a8785ce",
+    "zh:384acba136f1b347cac7831bb4e0396a370f6664e1c1242fce42a6fc55b9db8a",
+    "zh:409a01af5d873e4ac7e62cfd8c9a27638a719394ccf6a8de89ac4a1049275c20",
+    "zh:547eab553ea24cc9079fd80093c1611d036df089385bb4a38c5db21f6126e75e",
+    "zh:714a1fc3d1485deec10f4a49be556997f8ea0cc717db78fa0613f5bee728fcd7",
+    "zh:90d197c03a3bad2a8cfa7fc2396dc1601bf08be9368d399d58ec51654201c6fb",
+    "zh:9587b44249147b0e9d7619568cf46de126ec947ca5c56a1d740d8142b89919c2",
+    "zh:9d910ae66496833d4f85a4fe6b24649f74a1624f1502f63e9ff8201f29c0c1d1",
+    "zh:9f355767fc7f5ab769a60b46e42f9498f33ee95c3833b7d95c7f7c69fe101564",
+    "zh:d11d91da699d8c62f873cdea72bc26ab40cde4f18bc88ab6583ea836fee26ecd",
+    "zh:e0f9d50274f54acc2c5e300537d96a5aa03be650cfb66249a14ed45375014c77",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+  hashes = [
+    "h1:ydA0/SNRVB1o95btfshvYsmxA+jZFRZcvKzZSB+4S1M=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ module "azure_key_vault_tfvars" {
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.5 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 2.37.1 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.52.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
 ## Providers
 
@@ -65,6 +66,7 @@ module "azure_key_vault_tfvars" {
 |------|---------|
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | 2.43.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.75.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
 
 ## Resources
 
@@ -77,6 +79,7 @@ module "azure_key_vault_tfvars" {
 | [azurerm_monitor_diagnostic_setting.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_account.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
+| [null_resource.check_key_vault_secret_age_against_local_tfvars](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [azuread_user.key_vault_access](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_resource_group.existing_resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
@@ -93,6 +96,7 @@ module "azure_key_vault_tfvars" {
 | <a name="input_enable_diagnostic_storage_account"></a> [enable\_diagnostic\_storage\_account](#input\_enable\_diagnostic\_storage\_account) | When enabled, creates a Storage Account for the diagnostic logs, if one hasn't been specified for `diagnostic_storage_account_id` | `bool` | `false` | no |
 | <a name="input_enable_log_analytics_workspace"></a> [enable\_log\_analytics\_workspace](#input\_enable\_log\_analytics\_workspace) | When enabled, creates a Log Analyics Workspace, if one hasn't been specified for `diagnostic_log_analytics_workspace_id` | `bool` | `false` | no |
 | <a name="input_enable_resource_group_lock"></a> [enable\_resource\_group\_lock](#input\_enable\_resource\_group\_lock) | Enabling this will add a Resource Lock to the Resource Group preventing any resources from being deleted. | `bool` | `false` | no |
+| <a name="input_enable_tfvars_file_age_check"></a> [enable\_tfvars\_file\_age\_check](#input\_enable\_tfvars\_file\_age\_check) | Compares the file age of the tfvars file with the updated time of the Key Vault Secret, and prevents and older tfvars file updating a newer secret. | `bool` | `true` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment name. Will be used along with `project_name` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Name of an existing Resource Group to create the Key Vault within. If left empty, one will be created. | `string` | `""` | no |
 | <a name="input_key_vault_access_ipv4"></a> [key\_vault\_access\_ipv4](#input\_key\_vault\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the Key Vault | `list(string)` | n/a | yes |

--- a/locals.tf
+++ b/locals.tf
@@ -10,6 +10,7 @@ locals {
   key_vault_access_ipv4             = var.key_vault_access_ipv4
   key_vault_access_subnet_ids       = var.key_vault_access_subnet_ids
   tfvars_filename                   = var.tfvars_filename
+  enable_tfvars_file_age_check      = var.enable_tfvars_file_age_check
   enable_diagnostic_setting         = var.enable_diagnostic_setting
   enable_diagnostic_storage_account = var.diagnostic_storage_account_id == "" ? var.enable_diagnostic_storage_account : false
   enable_log_analytics_workspace    = var.diagnostic_log_analytics_workspace_id == "" ? var.enable_log_analytics_workspace : false

--- a/scripts/check-key-vault-secret-age-against-local-tfvars.sh
+++ b/scripts/check-key-vault-secret-age-against-local-tfvars.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+# exit on failures
+set -e
+set -o pipefail
+
+usage() {
+  echo "Usage: $(basename "$0") [OPTIONS]" 1>&2
+  echo "  -h                        - help"
+  echo "  -v <vault_name>           - Azure Key Vault name"
+  echo "  -s <secret_name>          - Azure Key Vault Secret name"
+  echo "  -f <local_tfars_filename> - Local tfvars file name"
+  exit 1
+}
+
+# if there are not arguments passed exit with usage
+if [ $# -eq 0 ]
+then
+  usage
+fi
+
+while getopts "v:s:f:h" opt; do
+  case $opt in
+    v)
+      VAULT_NAME=$OPTARG
+      ;;
+    s)
+      SECRET_NAME=$OPTARG
+      ;;
+    f)
+      LOCAL_TFVARS_FILE_NAME=$OPTARG
+      ;;
+    h)
+      usage
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+if [[
+  -z "$VAULT_NAME" ||
+  -z "$SECRET_NAME" ||
+  -z "$LOCAL_TFVARS_FILE_NAME"
+]]
+then
+  usage
+fi
+
+set +e
+KEY_VAULT_CHECK=$(az keyvault secret list --vault-name "$VAULT_NAME" 2>&1)
+set -e
+
+if ! jq -r >/dev/null 2>&1 <<< "$KEY_VAULT_CHECK"
+then
+  exit 0
+fi
+
+SECRET_UPDATED=$(jq -r \
+  --arg secret_name "$SECRET_NAME" \
+  '.[] | select(.name==$secret_name) | .attributes.updated' \
+  <<< "$KEY_VAULT_CHECK")
+
+if [ -z "$SECRET_UPDATED" ]
+then
+  exit 0
+fi
+
+SECRET_UPDATED=$(echo "$SECRET_UPDATED" | cut -d'+' -f1)
+SECRET_UPDATED_SECONDS=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$SECRET_UPDATED" "+%s")
+
+if [ "$SECRET_UPDATED_SECONDS" -gt "$(date -r "$LOCAL_TFVARS_FILE_NAME" +%s)" ]
+then
+  echo ""
+  echo ""
+  echo "Error: Your local tfvars file is older than the remote!"
+  echo ""
+  echo "Ensure you have the latest tfvars by running:"
+  echo ""
+  echo "  mv $LOCAL_TFVARS_FILE_NAME $LOCAL_TFVARS_FILE_NAME.old"
+  echo "  az keyvault secret download \\"
+  echo "    --file $LOCAL_TFVARS_FILE_NAME \\"
+  echo "    --encoding base64 \\"
+  echo "    --vault-name $VAULT_NAME \\"
+  echo "    --name $SECRET_NAME"
+  echo ""
+  echo "Or if you are sure your local tfvars are correct, just update the modified time by running:"
+  echo ""
+  echo "  touch $LOCAL_TFVARS_FILE_NAME"
+  echo ""
+  exit 1
+fi

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,12 @@ variable "secret_expiry_years" {
   default     = 5
 }
 
+variable "enable_tfvars_file_age_check" {
+  description = "Compares the file age of the tfvars file with the updated time of the Key Vault Secret, and prevents and older tfvars file updating a newer secret."
+  type        = bool
+  default     = true
+}
+
 variable "enable_diagnostic_setting" {
   description = "Enable Azure Diagnostics setting for the Key Vault"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -11,5 +11,10 @@ terraform {
       source  = "hashicorp/azuread"
       version = ">= 2.37.1"
     }
+
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.1"
+    }
   }
 }


### PR DESCRIPTION
* If someone runs terraform apply, without first ensuring they have the latest tfvars file (from Key Vault), it can inadvertantly overwrite the latest tfvars.
* This change checks the updated time of the Key Vault Secret, against the modified date of the local tfvars file