### PR TITLE
Restrict Diagnostic Log storage account to Azure Services only

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ module "azure_key_vault_tfvars" {
 | [azurerm_monitor_diagnostic_setting.tfvars](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) | resource |
 | [azurerm_resource_group.default](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_storage_account.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
+| [azurerm_storage_account_network_rules.logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_network_rules) | resource |
 | [null_resource.check_key_vault_secret_age_against_local_tfvars](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [azuread_user.key_vault_access](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/user) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |

--- a/logs-storage.tf
+++ b/logs-storage.tf
@@ -12,3 +12,13 @@ resource "azurerm_storage_account" "logs" {
 
   tags = local.tags
 }
+
+resource "azurerm_storage_account_network_rules" "logs" {
+  count = local.enable_diagnostic_storage_account ? 1 : 0
+
+  storage_account_id         = azurerm_storage_account.logs[0].id
+  default_action             = "Deny"
+  bypass                     = ["AzureServices"]
+  virtual_network_subnet_ids = []
+  ip_rules                   = []
+}


### PR DESCRIPTION
This Storage Account is only used for Diagnostic Logs from Key Vault so we ought to restrict access to just the Azure services and default `deny` all others