### PR TITLE
Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "terraform"
-    directory: "/"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
* We're using Renovate to track dependencies instead