### PR TITLE
Toggle RBAC authorisation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ module "azure_key_vault_tfvars" {
   enable_resource_group_lock =  false
   azure_location             = "uk-south"
 
-  key_vault_access_users = [
-    "my_email.address.suffix#EXT#@platformidentity.onmicrosoft.com",
-  ]
+  # (legacy) Grant access to Key Vault using Access Policy
+  # key_vault_access_users = [
+  #   "my_email.address.suffix#EXT#@platformidentity.onmicrosoft.com",
+  # ]
+
+  # (Preferred) Leverage Azure RBAC to grant access to Key Vault
+  key_vault_access_use_rbac_authorization = true
 
   # List of IPV4 Addresses that are permitted to access the Key Vault
   key_vault_access_ipv4 = [
@@ -102,6 +106,7 @@ module "azure_key_vault_tfvars" {
 | <a name="input_existing_resource_group"></a> [existing\_resource\_group](#input\_existing\_resource\_group) | Name of an existing Resource Group to create the Key Vault within. If left empty, one will be created. | `string` | `""` | no |
 | <a name="input_key_vault_access_ipv4"></a> [key\_vault\_access\_ipv4](#input\_key\_vault\_access\_ipv4) | List of IPv4 Addresses that are permitted to access the Key Vault | `list(string)` | n/a | yes |
 | <a name="input_key_vault_access_subnet_ids"></a> [key\_vault\_access\_subnet\_ids](#input\_key\_vault\_access\_subnet\_ids) | List of Azure Subnet IDs that are permitted to access the Key Vault | `list(string)` | `[]` | no |
+| <a name="input_key_vault_access_use_rbac_authorization"></a> [key\_vault\_access\_use\_rbac\_authorization](#input\_key\_vault\_access\_use\_rbac\_authorization) | Use RBAC to handle access controls for the Key Vault | `bool` | `false` | no |
 | <a name="input_key_vault_access_users"></a> [key\_vault\_access\_users](#input\_key\_vault\_access\_users) | List of users that require access to the Key Vault. This should be a list of User Principle Names (Found in Active Directory) that need to run terraform | `list(string)` | n/a | yes |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Project name. Will be used along with `environment` as a prefix for all resources. | `string` | n/a | yes |
 | <a name="input_secret_expiry_years"></a> [secret\_expiry\_years](#input\_secret\_expiry\_years) | Number of years from now when the Key Vault secret should be considered expired | `number` | `5` | no |

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -5,7 +5,7 @@ resource "azurerm_key_vault" "tfvars" {
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
   soft_delete_retention_days = 7
-  enable_rbac_authorization  = false
+  enable_rbac_authorization  = local.key_vault_access_use_rbac_authorization
   purge_protection_enabled   = true
 
   dynamic "access_policy" {

--- a/locals.tf
+++ b/locals.tf
@@ -1,19 +1,20 @@
 locals {
-  environment                       = var.environment
-  project_name                      = var.project_name
-  existing_resource_group           = var.existing_resource_group
-  azure_location                    = var.azure_location
-  resource_prefix                   = "${local.environment}${local.project_name}"
-  resource_group                    = local.existing_resource_group == "" ? azurerm_resource_group.default[0] : data.azurerm_resource_group.existing_resource_group[0]
-  enable_resource_group_lock        = var.enable_resource_group_lock
-  key_vault_access_users            = toset(var.key_vault_access_users)
-  key_vault_access_ipv4             = var.key_vault_access_ipv4
-  key_vault_access_subnet_ids       = var.key_vault_access_subnet_ids
-  tfvars_filename                   = var.tfvars_filename
-  enable_tfvars_file_age_check      = var.enable_tfvars_file_age_check
-  enable_diagnostic_setting         = var.enable_diagnostic_setting
-  enable_diagnostic_storage_account = var.diagnostic_storage_account_id == "" ? var.enable_diagnostic_storage_account : false
-  enable_log_analytics_workspace    = var.diagnostic_log_analytics_workspace_id == "" ? var.enable_log_analytics_workspace : false
+  environment                             = var.environment
+  project_name                            = var.project_name
+  existing_resource_group                 = var.existing_resource_group
+  azure_location                          = var.azure_location
+  resource_prefix                         = "${local.environment}${local.project_name}"
+  resource_group                          = local.existing_resource_group == "" ? azurerm_resource_group.default[0] : data.azurerm_resource_group.existing_resource_group[0]
+  enable_resource_group_lock              = var.enable_resource_group_lock
+  key_vault_access_users                  = toset(var.key_vault_access_users)
+  key_vault_access_ipv4                   = var.key_vault_access_ipv4
+  key_vault_access_subnet_ids             = var.key_vault_access_subnet_ids
+  key_vault_access_use_rbac_authorization = var.key_vault_access_use_rbac_authorization
+  tfvars_filename                         = var.tfvars_filename
+  enable_tfvars_file_age_check            = var.enable_tfvars_file_age_check
+  enable_diagnostic_setting               = var.enable_diagnostic_setting
+  enable_diagnostic_storage_account       = var.diagnostic_storage_account_id == "" ? var.enable_diagnostic_storage_account : false
+  enable_log_analytics_workspace          = var.diagnostic_log_analytics_workspace_id == "" ? var.enable_log_analytics_workspace : false
   diagnostic_log_analytics_workspace_id = var.diagnostic_log_analytics_workspace_id != "" ? var.diagnostic_log_analytics_workspace_id : (
     local.enable_log_analytics_workspace ? azurerm_log_analytics_workspace.key_vault[0].id : null
   )

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "key_vault_access_subnet_ids" {
   default     = []
 }
 
+variable "key_vault_access_use_rbac_authorization" {
+  description = "Use RBAC to handle access controls for the Key Vault"
+  type        = bool
+  default     = false
+}
+
 variable "tfvars_filename" {
   description = "tfvars filename. This file is uploaded and stored encrupted within Key Vault, to ensure that the latest tfvars are stored in a shared place."
   type        = string


### PR DESCRIPTION
Key Vault Access Policies are now legacy (https://learn.microsoft.com/en-gb/azure/key-vault/general/assign-access-policy?WT.mc_id=Portal-Microsoft_Azure_KeyVault&tabs=azure-portal) We should switch to enabling RBAC across all of our Key Vaults. This means access controls can be handled through AAD instead.

https://learn.microsoft.com/en-gb/azure/key-vault/general/rbac-access-policy
https://learn.microsoft.com/en-gb/azure/key-vault/general/rbac-migration
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault#enable_rbac_authorization

Seeing as though this change could break existing access controls, I have set the default to false which mirrors existing behaviour