### PR TITLE
Support Windows for local-exec bash

### DIFF
--- a/key-vault.tf
+++ b/key-vault.tf
@@ -45,7 +45,7 @@ resource "null_resource" "check_key_vault_secret_age_against_local_tfvars" {
   count = local.enable_tfvars_file_age_check ? 1 : 0
 
   provisioner "local-exec" {
-    interpreter = ["/bin/bash", "-c"]
+    interpreter = [local.bash, "-c"]
     command     = "${path.module}/scripts/check-key-vault-secret-age-against-local-tfvars.sh -v \"${azurerm_key_vault.tfvars.name}\" -s \"${local.resource_prefix}-tfvars\" -f ${local.tfvars_filename}"
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -27,4 +27,7 @@ locals {
   secret_expiry_years      = var.secret_expiry_years
   timestamp_parts          = regex("^(?P<year>\\d+)(?P<remainder>-.*)$", timestamp())
   year_from_now            = format("%d%s", local.timestamp_parts.year + local.secret_expiry_years, local.timestamp_parts.remainder)
+
+  is_windows = can(regex("^[A-Za-z]:", abspath(path.root)))
+  bash       = local.is_windows ? "C:/Program Files/Git/bin/bash.exe" : "/bin/bash"
 }


### PR DESCRIPTION
* This adds in a check to see if terraform is running on a Windows machine, and then selects the correct binary to run bash (either Git Bash or /bin/bash)