### PR TITLE
Remove tfsec

### DIFF
--- a/.github/workflows/continuous-integration-tfsec.yml
+++ b/.github/workflows/continuous-integration-tfsec.yml
@@ -8,7 +8,3 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
-      - name: tfsec
-        uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
-        with:
-          github_token: ${{ github.token }}


### PR DESCRIPTION
* the risk of running things provided by aquasecurity is currently quite high given they have been compromised twice in a month.